### PR TITLE
Fix Patch-replace behavior in JSNode.java

### DIFF
--- a/src/main/java/io/inversion/cloud/model/JSNode.java
+++ b/src/main/java/io/inversion/cloud/model/JSNode.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016-2019 Rocket Partners, LLC
  * https://github.com/inversion-api
- * 
+ *
  * Copyright 2008-2016 Wells Burke
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -120,7 +120,7 @@ public class JSNode implements Map<String, Object>
       }
       else if (!myVal.getClass().equals(theirVal.getClass()))
       {
-         patches.add(new JSNode("op", "replace", "path", path, myVal));
+         patches.add(new JSNode("op", "replace", "path", path, "value", myVal));
       }
       else if (myVal instanceof JSNode)
       {
@@ -128,7 +128,7 @@ public class JSNode implements Map<String, Object>
       }
       else if (!myVal.toString().equals(theirVal.toString()))
       {
-         patches.add(new JSNode("op", "replace", "path", path, myVal));
+         patches.add(new JSNode("op", "replace", "path", path, "value", myVal));
       }
    }
 
@@ -357,7 +357,7 @@ public class JSNode implements Map<String, Object>
 
    /**
     * Vanity method to make sure the attributes prints out first
-    * 
+    *
     * @param name
     * @param value
     * @return

--- a/src/test/java/io/inversion/cloud/model/TestJSNode.java
+++ b/src/test/java/io/inversion/cloud/model/TestJSNode.java
@@ -67,7 +67,7 @@ public class TestJSNode extends TestCase
    /**
     * This test was developed for an error in diff/patch that could result in the same JSNode
     * appearing multiple times in the object graph and causing serialization problems.
-    * 
+    *
     * The fix was to copy the patches before applying or after computing inside to the JSNode methods
     */
    @Test
@@ -110,6 +110,24 @@ public class TestJSNode extends TestCase
 
       array2.patch(patches);
 
+   }
+
+   /**
+    * This test was developed to test the patch replace behavior, which caused a replacement of
+    * a value in a json package to be set to null instead of the new value
+    */
+   @Test
+   public void testDiff5()
+   {
+      List found = null;
+      JSNode doc1 = JSNode.parseJsonNode(Utils.read(getClass().getResourceAsStream("testDiff5.1.json")));
+      JSNode doc2 = JSNode.parseJsonNode(Utils.read(getClass().getResourceAsStream("testDiff5.2.json")));
+
+      JSArray patches = doc2.diff(doc1);
+
+      doc1.patch(patches);
+
+      assertTrue(doc1.toString().equals(doc2.toString()));
    }
 
 }

--- a/src/test/resources/io/inversion/cloud/model/testDiff5.1.json
+++ b/src/test/resources/io/inversion/cloud/model/testDiff5.1.json
@@ -1,0 +1,5 @@
+[
+	{
+		"href": "http://localhost:8081/v1/customers/1"
+	}
+]

--- a/src/test/resources/io/inversion/cloud/model/testDiff5.2.json
+++ b/src/test/resources/io/inversion/cloud/model/testDiff5.2.json
@@ -1,0 +1,5 @@
+[
+	{
+		"href": "http://localhost:8081/v1/customers/2"
+	}
+]


### PR DESCRIPTION
The patch behavior in JSNode for replacing a value was setting all replaced values to null due to a bug in the creation of the replace patch item in the patch list. Fixed. New test created to test this specific problem.