### PR TITLE
Bt/with forwarded headers default true

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.7.12
+version=0.7.13
 awsSdkVersion=1.11+
 azureSdkVersion=2.4+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.7.11
+version=0.7.12
 awsSdkVersion=1.11+
 azureSdkVersion=2.4+

--- a/inversion-api/src/main/java/io/inversion/cloud/utils/RestClient.java
+++ b/inversion-api/src/main/java/io/inversion/cloud/utils/RestClient.java
@@ -77,7 +77,7 @@ public class RestClient
    protected ArrayListValuedHashMap<String, String> forcedHeaders    = new ArrayListValuedHashMap();
 
    //https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
-   protected boolean                                forwardHeaders   = false;
+   protected boolean                                forwardHeaders   = true;
    protected Set                                    whitelistHeaders = new HashSet(Arrays.asList("authorization", "cookie", "x-forwarded-host", " x-forwarded-proto"));
    protected Set                                    blacklistHeaders = new HashSet(Arrays.asList("content-length", "content-type", "content-encoding", "content-language", "content-location", "content-md5", "host"));
 


### PR DESCRIPTION
The old default of false wasn't useful. Setting it to true as the default behavior.