### PR TITLE
Wb/RestClient support for variabilized urls and easy getResponse() overrides

### DIFF
--- a/inversion-api/src/main/java/io/inversion/cloud/model/Request.java
+++ b/inversion-api/src/main/java/io/inversion/cloud/model/Request.java
@@ -16,6 +16,7 @@
  */
 package io.inversion.cloud.model;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +56,10 @@ public class Request
    protected Uploader                               uploader       = null;
 
    protected int                                    retryAttempts  = -1;
+
+   int                                              retryCount     = 0;
+   File                                             retryFile;
+   int                                              totalRetries   = 0;                           // this number doesn't get reset and is the true measure of how many retries occured
 
    boolean                                          explain        = false;
 
@@ -557,6 +562,43 @@ public class Request
    public Validation validate(String propOrJsonPath, String customErrorMessage)
    {
       return new Validation(this, propOrJsonPath, customErrorMessage);
+   }
+
+   public boolean isLocalRequest()
+   {
+      String url = getUrl().toString();
+      return chain != null && !(url.startsWith("http:") || url.startsWith("https://"));
+   }
+
+   public int getRetryCount()
+   {
+      return retryCount;
+   }
+
+   public void incrementRetryCount()
+   {
+      this.totalRetries++;
+      this.retryCount++;
+   }
+
+   public void resetRetryCount()
+   {
+      this.retryCount = 0;
+   }
+
+   public int getTotalRetries()
+   {
+      return totalRetries;
+   }
+
+   public File getRetryFile()
+   {
+      return retryFile;
+   }
+
+   public void setRetryFile(File retryFile)
+   {
+      this.retryFile = retryFile;
    }
 
    public List<Upload> getUploads()

--- a/inversion-api/src/main/java/io/inversion/cloud/utils/FutureResponse.java
+++ b/inversion-api/src/main/java/io/inversion/cloud/utils/FutureResponse.java
@@ -33,19 +33,16 @@ import java.util.concurrent.TimeoutException;
 
 public abstract class FutureResponse implements RunnableFuture<Response>
 {
-   static Log            log          = LogFactory.getLog(HttpUtils.class);
+   static Log            log        = LogFactory.getLog(HttpUtils.class);
 
-   long                  createdAt    = System.currentTimeMillis();
+   long                  createdAt  = System.currentTimeMillis();
 
-   Chain                 chain        = Chain.peek();
-   Request               request      = null;
-   Response              response     = null;
-   List<ResponseHandler> onSuccess    = new ArrayList();
-   List<ResponseHandler> onFailure    = new ArrayList();
-   List<ResponseHandler> onResponse   = new ArrayList();
-   int                   retryCount   = 0;
-   File                  retryFile;
-   int                   totalRetries = 0;                                 // this number doesn't get reset and is the true measure of how many retries occured
+   Chain                 chain      = Chain.peek();
+   Request               request    = null;
+   Response              response   = null;
+   List<ResponseHandler> onSuccess  = new ArrayList();
+   List<ResponseHandler> onFailure  = new ArrayList();
+   List<ResponseHandler> onResponse = new ArrayList();
 
    public FutureResponse()
    {
@@ -262,12 +259,6 @@ public abstract class FutureResponse implements RunnableFuture<Response>
       return response;
    }
 
-   public boolean isLocalRequest()
-   {
-      String url = request.getUrl().toString();
-      return chain != null && !(url.startsWith("http:") || url.startsWith("https://"));
-   }
-
    public Request getRequest()
    {
       return request;
@@ -283,37 +274,6 @@ public abstract class FutureResponse implements RunnableFuture<Response>
    public boolean isDone()
    {
       return response != null;
-   }
-
-   protected int getRetryCount()
-   {
-      return retryCount;
-   }
-
-   public void incrementRetryCount()
-   {
-      this.totalRetries++;
-      this.retryCount++;
-   }
-
-   public void resetRetryCount()
-   {
-      this.retryCount = 0;
-   }
-
-   public int getTotalRetries()
-   {
-      return totalRetries;
-   }
-
-   public File getRetryFile()
-   {
-      return retryFile;
-   }
-
-   public void setRetryFile(File retryFile)
-   {
-      this.retryFile = retryFile;
    }
 
    public static interface ResponseHandler

--- a/inversion-api/src/main/java/io/inversion/cloud/utils/HttpUtils.java
+++ b/inversion-api/src/main/java/io/inversion/cloud/utils/HttpUtils.java
@@ -149,9 +149,9 @@ public class HttpUtils
                   {
                      req = new HttpGet(url);
 
-                     if (this.getRetryFile() != null && this.getRetryFile().length() > 0)
+                     if (request.getRetryFile() != null && request.getRetryFile().length() > 0)
                      {
-                        long range = this.getRetryFile().length();
+                        long range = request.getRetryFile().length();
                         headers.remove("Range");
                         headers.put("Range", "bytes=" + range + "-");
 
@@ -212,7 +212,7 @@ public class HttpUtils
                   if (response.getStatusCode() >= 200 && response.getStatusCode() <= 300)
                   {
                      debug("Resetting retry count");
-                     this.resetRetryCount();
+                     request.resetRetryCount();
                   }
 
                   Url u = new Url(url);
@@ -226,9 +226,9 @@ public class HttpUtils
                      retryable = false; // do not allow this to retry on a 404
                      return; //will go to finally block
                   }
-                  else if (this.getRetryFile() != null && this.getRetryFile().length() == response.getContentRangeStart() && "bytes".equalsIgnoreCase(response.getContentRangeUnit()))
+                  else if (request.getRetryFile() != null && request.getRetryFile().length() == response.getContentRangeStart() && "bytes".equalsIgnoreCase(response.getContentRangeUnit()))
                   {
-                     tempFile = this.getRetryFile();
+                     tempFile = request.getRetryFile();
                      debug("## Using existing file .. " + tempFile);
                   }
                   else if (response.getStatusCode() == 206)
@@ -293,18 +293,18 @@ public class HttpUtils
 
                   // If this is a retryable response, submit it later
                   // Since we resetRetryCount upon any successful response, we are still guarding against a crazy large amount of retries with the TOTAL_MAX_RETRY_ATTEMPTS
-                  if (retryable && this.getRetryCount() < request.getRetryAttempts() && !response.isSuccess() && this.getTotalRetries() < TOTAL_MAX_RETRY_ATTEMPTS)
+                  if (retryable && request.getRetryCount() < request.getRetryAttempts() && !response.isSuccess() && request.getTotalRetries() < TOTAL_MAX_RETRY_ATTEMPTS)
                   {
-                     this.incrementRetryCount();
+                     request.incrementRetryCount();
 
-                     long timeout = (1000 * this.getRetryCount() * this.getRetryCount()) + (int) (1000 * Math.random() * this.getRetryCount());
+                     long timeout = (1000 * request.getRetryCount() * request.getRetryCount()) + (int) (1000 * Math.random() * request.getRetryCount());
 
-                     debug("retrying: " + this.getRetryCount() + " - " + timeout + " - " + url);
+                     debug("retrying: " + request.getRetryCount() + " - " + timeout + " - " + url);
 
                      // Set this for possible resumable download on the next try
-                     if (this.getRetryFile() == null && response.getStatusCode() == 200)
+                     if (request.getRetryFile() == null && response.getStatusCode() == 200)
                      {
-                        this.setRetryFile(response.getFile());
+                        request.setRetryFile(response.getFile());
                      }
 
                      submitLater(this, timeout);

--- a/inversion-api/src/test/java/io/inversion/cloud/utils/RestClientTest.java
+++ b/inversion-api/src/test/java/io/inversion/cloud/utils/RestClientTest.java
@@ -23,11 +23,12 @@ public class RestClientTest
       final int[] tries = new int[]{0};
       RestClient client = new RestClient()
          {
-            protected Response getResponse(FutureResponse future)
+            @Override
+            protected Response getResponse(Request request)
             {
                tries[0] += 1;
                Response resp = new Response();
-               if (future.getRetryCount() >= 4)
+               if (request.getRetryCount() >= 4)
                {
                   //simulates an HTTP response that was initially successful
                   //but then threw an exception on content download
@@ -45,7 +46,7 @@ public class RestClientTest
       FutureResponse fut = client.call("GET", "url", null, null, 5, null);
       fut.get();
       assertEquals(21, tries[0]);
-      assertEquals(20, fut.getTotalRetries());
+      assertEquals(20, fut.request.getTotalRetries());
    }
 
    @Test
@@ -54,7 +55,8 @@ public class RestClientTest
       final int[] statusCode = new int[]{404};
       RestClient client = new RestClient()
          {
-            protected Response getResponse(FutureResponse future)
+            @Override
+            protected Response getResponse(Request request)
             {
                Response resp = new Response();
                resp.withStatusCode(statusCode[0]);
@@ -64,12 +66,12 @@ public class RestClientTest
          };
       FutureResponse resp = client.call("GET", "url", null, null, 5, null);
       resp.get();
-      assertEquals(0, resp.getRetryCount());
+      assertEquals(0, resp.request.getRetryCount());
 
       statusCode[0] = 500;
       resp = client.call("GET", "url", null, null, 5, null);
       resp.get();
-      assertEquals(5, resp.getRetryCount());
+      assertEquals(5, resp.request.getRetryCount());
 
    }
 
@@ -80,7 +82,8 @@ public class RestClientTest
 
       RestClient client = new RestClient()
          {
-            protected Response getResponse(FutureResponse future)
+            @Override
+            protected Response getResponse(Request request)
             {
                thread[0] = Thread.currentThread();
                return new Response(null);

--- a/inversion-api/src/test/java/io/inversion/cloud/utils/RestClientTest.java
+++ b/inversion-api/src/test/java/io/inversion/cloud/utils/RestClientTest.java
@@ -16,6 +16,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RestClientTest
 {
+   @Test
+   public void buildUrl_variable_replaced()
+   {
+      System.setProperty("theirService.url", "http://somehost/${tenant}/books/${something}/abcd");
+
+      Request req = new Request("GET", "http://myservice?tenant=12345");
+      RestClient client = new RestClient("theirService");
+
+      try
+      {
+         Chain.push(null, req, null);
+         String url = client.buildUrl();
+         assertEquals("http://somehost/12345/books/${something}/abcd", url);
+      }
+      finally
+      {
+         Chain.pop();
+      }
+
+   }
 
    @Test
    public void test_retriesMax()


### PR DESCRIPTION
Attempt to make RestClient super clean for easy filtering/transformations of requests/responses with per request url variabilization based on inbound request params and ${paramName} in the remote host url.  Should make forwarding tenants params via URL path trivial.