### PR TITLE
added req gzipping to RestClient and resp gzipping to Engine/SpringBoot

### DIFF
--- a/inversion-api/src/main/java/io/inversion/EngineServlet.java
+++ b/inversion-api/src/main/java/io/inversion/EngineServlet.java
@@ -16,9 +16,17 @@
  */
 package io.inversion;
 
-import io.inversion.Request.Upload;
-import io.inversion.Request.Uploader;
-import io.inversion.utils.Utils;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -26,8 +34,10 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
-import java.io.*;
-import java.util.*;
+
+import io.inversion.Request.Upload;
+import io.inversion.Request.Uploader;
+import io.inversion.utils.Utils;
 
 public class EngineServlet extends HttpServlet {
     static class EngineServletLocal {
@@ -171,6 +181,8 @@ public class EngineServlet extends HttpServlet {
         try {
             InputStream inputStream = request.getInputStream();
             if (inputStream != null) {
+                if ("gzip".equalsIgnoreCase(request.getHeader("Content-Encoding")))
+                    inputStream = new GZIPInputStream(inputStream, 1024);
                 bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
                 char[] charBuffer = new char[128];
                 int    bytesRead  = -1;
@@ -220,7 +232,7 @@ public class EngineServlet extends HttpServlet {
                 byte[] bytes       = res.getOutput().getBytes();
 
                 http.setContentType(contentType);
-                res.withHeader("Content-Length", bytes.length + "");
+                http.setContentLength(bytes.length);
                 res.debug("Content-Length " + bytes.length + "");
 
                 out.write(bytes);

--- a/inversion-api/src/main/java/io/inversion/Request.java
+++ b/inversion-api/src/main/java/io/inversion/Request.java
@@ -322,6 +322,7 @@ public class Request {
     }
 
     public String getHeader(String key) {
+        key = key.toLowerCase();
         List<String> vals = headers.get(key);
         if (vals != null && vals.size() > 0)
             return vals.get(0);
@@ -329,6 +330,7 @@ public class Request {
     }
 
     public void removeHeader(String key) {
+        key = key.toLowerCase();
         headers.remove(key);
     }
 
@@ -340,6 +342,7 @@ public class Request {
     }
 
     public void withHeader(String key, String value) {
+        key = key.toLowerCase();
         if (!headers.containsMapping(key, value))
             headers.put(key, value);
     }

--- a/inversion-api/src/main/java/io/inversion/utils/RestClient.java
+++ b/inversion-api/src/main/java/io/inversion/utils/RestClient.java
@@ -134,50 +134,57 @@ import java.util.zip.GZIPOutputStream;
  * </pre>
  */
 public class RestClient {
-    static Log log = LogFactory.getLog(RestClient.class);
 
-    protected String name = null;
+    static Log                                       log              = LogFactory.getLog(RestClient.class);
+
+    protected String                                 name             = null;
 
     /**
      * Optional base url that will be prepended to the url arg of any calls assuming that the url arg supplied is a relative path and not an absolute url.
      */
-    protected String url = null;
+    protected String                                 url              = null;
 
     /**
      * Indicates the headers from the root inbound Request being handled on this Chain should be included on this request minus any blacklisted headers.
      */
-    protected boolean forwardHeaders = false;
+    protected boolean                                forwardHeaders   = false;
 
     /**
      * Indicates that a request body should be gzipped and the content-encoding header should be sent with value "gzip".
+     * <p>
+     * Valid values include "on", "off", "force" or the number of bytes of content that should trigger compression.
+     * <p>
+     * The default value is "1024" which implies "on" for anything over 1KB.
+     * <p>
+     * This property is modeled off of {@see org.apache.coyote.CompressionConfig.setCompression()}.
      */
-    protected boolean gzipRequest = false;
+    protected String                                 compression      = "1024";
 
     /**
      * Always forward these headers.
      *
      * @see #shouldForwardHeader(String)
      */
-    protected Set whitelistHeaders = new HashSet(Arrays.asList("authorization", "cookie", "x-forwarded-host", " x-forwarded-proto"));
+    protected Set                                    whitelistHeaders = new HashSet(Arrays.asList("authorization", "cookie", "x-forwarded-host", " x-forwarded-proto"));
 
     /**
      * Never forward these headers.
      *
      * @see #shouldForwardHeader(String)
      */
-    protected Set blacklistHeaders = new HashSet(Arrays.asList("content-length", "content-type", "content-encoding", "content-language", "content-location", "content-md5", "host"));
+    protected Set                                    blacklistHeaders = new HashSet(Arrays.asList("content-length", "content-type", "content-encoding", "content-language", "content-location", "content-md5", "host"));
 
     /**
      * Headers that are always sent regardless of <code>forwardHeaders</code>, <code>whitelistHeaders</code> and <code>blacklistHeaders</code> state.
      * <p>
      * These headers will overwrite any caller supplied or forwarded header with the same key, not append to the value list.
      */
-    protected ArrayListValuedHashMap<String, String> forcedHeaders = new ArrayListValuedHashMap();
+    protected ArrayListValuedHashMap<String, String> forcedHeaders    = new ArrayListValuedHashMap();
 
     /**
      * Indicates the params from the root inbound Request being handled on this Chain should be included on this request minus any blacklisted params.
      */
-    protected boolean forwardParams = false;
+    protected boolean                                forwardParams    = false;
 
     /**
      * Always forward these params.
@@ -185,7 +192,7 @@ public class RestClient {
      *
      * @see #shouldForwardParam(String)
      */
-    protected Set<String> whitelistParams = new HashSet();
+    protected Set<String>                            whitelistParams  = new HashSet();
 
     /**
      * Never forward these params.
@@ -193,19 +200,19 @@ public class RestClient {
      *
      * @see #shouldForwardParam(String)
      */
-    protected Set<String> blacklistParams = new HashSet();
+    protected Set<String>                            blacklistParams  = new HashSet();
 
     /**
      * The thread pool executor used to make asynchronous requests
      */
-    protected Executor executor = null;
+    protected Executor                               executor         = null;
 
     /**
      * The default maximum number of times to retry a request
      * <p>
      * The default value is zero meaning by default, failed requests will not be retried
      */
-    protected int retryMax = 0;
+    protected int                                    retryMax         = 0;
 
     /**
      * The length of time before the first retry.
@@ -214,45 +221,45 @@ public class RestClient {
      *
      * @see #computeTimeout(Request)
      */
-    protected int retryTimeoutMin = 10;
+    protected int                                    retryTimeoutMin  = 10;
 
     /**
      * The maximum amount of time to wait before a single retry.
      *
      * @see #computeTimeout(Request)
      */
-    protected int retryTimeoutMax = 1000;
+    protected int                                    retryTimeoutMax  = 1000;
 
     /**
      * Parameter for default HttpClient configuration
      *
      * @see org.apache.http.client.config.RequstConfig.setSocketTimeout
      */
-    protected int socketTimeout = 30000;
+    protected int                                    socketTimeout    = 30000;
 
     /**
      * Parameter for default HttpClient configuration
      *
      * @see org.apache.http.client.config.RequstConfig.setConnectTimeout
      */
-    protected int connectTimeout = 30000;
+    protected int                                    connectTimeout   = 30000;
 
     /**
      * Parameter for default HttpClient configuration
      *
      * @see org.apache.http.client.config.RequstConfig.setConnectionRequestTimeout
      */
-    protected int requestTimeout = 30000;
+    protected int                                    requestTimeout   = 30000;
 
     /**
      * The underlying HttpClient use for all network comms.
      */
-    protected HttpClient httpClient = null;
+    protected HttpClient                             httpClient       = null;
 
     /**
      * The timer used it trigger retries.
      */
-    Timer timer = null;
+    Timer                                            timer            = null;
 
     public RestClient() {
 
@@ -370,8 +377,8 @@ public class RestClient {
             params = newParams;
         }
 
-        Request        request = buildRequest(method, url, params, (body != null ? body.toString() : null), headers, retryMax);
-        FutureResponse future  = buildFuture(request);
+        Request request = buildRequest(method, url, params, (body != null ? body.toString() : null), headers, retryMax);
+        FutureResponse future = buildFuture(request);
 
         submit(future);
 
@@ -386,8 +393,8 @@ public class RestClient {
         if (forwardHeaders) {
             Chain chain = Chain.first();//gets the root chain
             if (chain != null) {
-                Request                                originalInboundRequest = chain.getRequest();
-                ArrayListValuedHashMap<String, String> inboundHeaders         = originalInboundRequest.getHeaders();
+                Request originalInboundRequest = chain.getRequest();
+                ArrayListValuedHashMap<String, String> inboundHeaders = originalInboundRequest.getHeaders();
                 if (inboundHeaders != null) {
                     for (String key : inboundHeaders.keySet()) {
                         if (shouldForwardHeader(key)) {
@@ -411,8 +418,8 @@ public class RestClient {
         if (forwardParams) {
             Chain chain = Chain.first();
             if (chain != null) {
-                Request             originalInboundRequest = chain.getRequest();
-                Map<String, String> origionalParams        = originalInboundRequest.getUrl().getParams();
+                Request originalInboundRequest = chain.getRequest();
+                Map<String, String> origionalParams = originalInboundRequest.getUrl().getParams();
                 if (origionalParams.size() > 0) {
                     for (String key : origionalParams.keySet()) {
                         if (shouldForwardParam(key)) {
@@ -429,6 +436,7 @@ public class RestClient {
 
     FutureResponse buildFuture(Request request) {
         final FutureResponse future = new FutureResponse(request) {
+
             public void run() {
                 Response response = null;
                 try {
@@ -496,7 +504,7 @@ public class RestClient {
      * @return
      */
     protected Response doRequest(Request request) {
-        String   url      = request.getUrl().toString();
+        String url = request.getUrl().toString();
         Response response = new Response(url);
 
         try {
@@ -509,15 +517,15 @@ public class RestClient {
     }
 
     Response doRequest0(Request request) throws Exception {
-        String          m        = request.getMethod();
-        HttpRequestBase req      = null;
-        File            tempFile = null;
+        String m = request.getMethod();
+        HttpRequestBase req = null;
+        File tempFile = null;
 
-        String   url      = request.getUrl().toString();
+        String url = request.getUrl().toString();
         Response response = new Response(url);
 
         try {
-            HttpClient   h  = getHttpClient();
+            HttpClient h = getHttpClient();
             HttpResponse hr = null;
 
             response.debug("--request header------");
@@ -558,17 +566,24 @@ public class RestClient {
             if (request.getBody() != null && req instanceof HttpEntityEnclosingRequestBase) {
                 response.debug("\r\n--request body--------");
 
-                if (isGzipRequest()) {
+                byte[] bytes = request.getBody().getBytes("UTF-8");
+
+                boolean doCompress = "force".equalsIgnoreCase(compression);
+                if (!doCompress && !"off".equalsIgnoreCase("compression")) {
+                    if (bytes.length >= Long.parseLong(compression))
+                        doCompress = true;
+                }
+                if (doCompress) {
                     req.setHeader("Content-Encoding", "gzip");
-                    ByteArrayOutputStream obj  = new ByteArrayOutputStream();
-                    GZIPOutputStream      gzip = new GZIPOutputStream(obj);
-                    gzip.write(request.getBody().getBytes("UTF-8"));
+                    ByteArrayOutputStream obj = new ByteArrayOutputStream();
+                    GZIPOutputStream gzip = new GZIPOutputStream(obj);
+                    gzip.write(bytes);
                     gzip.flush();
                     gzip.close();
-                    ((HttpEntityEnclosingRequestBase) req).setEntity(new ByteArrayEntity(obj.toByteArray()));
-                } else {
-                    ((HttpEntityEnclosingRequestBase) req).setEntity(new StringEntity(request.getBody(), "UTF-8"));
+                    bytes = obj.toByteArray();
                 }
+
+                ((HttpEntityEnclosingRequestBase) req).setEntity(new ByteArrayEntity(bytes));
             }
 
             if (Utils.empty(request.getHeader("Accept-Encoding"))) {
@@ -593,7 +608,7 @@ public class RestClient {
             log.debug("RESPONSE CODE ** " + response.getStatusCode() + "   (" + response.getStatus() + ")");
             log.debug("CONTENT RANGE RESPONSE HEADER ** " + response.getHeader("Content-Range"));
 
-            Url    u        = new Url(url);
+            Url u = new Url(url);
             String fileName = u.getFile();
             if (fileName == null)
                 fileName = Utils.slugify(u.toString());
@@ -698,9 +713,9 @@ public class RestClient {
                 || ex instanceof org.apache.http.NoHttpResponseException //
                 || ex instanceof java.net.ConnectException //
                 || ex instanceof java.net.SocketTimeoutException //
-                //|| ex instanceof java.net.NoRouteToHostException //
-                //|| ex instanceof java.net.UnknownHostException //
-                ;
+        //|| ex instanceof java.net.NoRouteToHostException //
+        //|| ex instanceof java.net.UnknownHostException //
+        ;
     }
 
     synchronized void submit(FutureResponse future) {
@@ -713,6 +728,7 @@ public class RestClient {
         }
 
         timer.schedule(new TimerTask() {
+
             @Override
             public void run() {
                 submit(future);
@@ -741,6 +757,7 @@ public class RestClient {
             // setup a Trust Strategy that allows all certificates.
             //
             SSLContext sslContext = new SSLContextBuilder().loadTrustMaterial(null, new TrustStrategy() {
+
                 public boolean isTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
                     return true;
                 }
@@ -760,7 +777,7 @@ public class RestClient {
 
             // now, we create connection-manager using our Registry.
             //      -- allows multi-threaded use
-            PoolingHttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager(RegistryBuilder.<ConnectionSocketFactory>create().register("http", PlainConnectionSocketFactory.getSocketFactory()).register("https", sslSocketFactory).build());
+            PoolingHttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager(RegistryBuilder.<ConnectionSocketFactory> create().register("http", PlainConnectionSocketFactory.getSocketFactory()).register("https", sslSocketFactory).build());
 
             b.setConnectionManager(connMgr);
 
@@ -775,6 +792,7 @@ public class RestClient {
     }
 
     static class HttpDeleteWithBody extends HttpEntityEnclosingRequestBase {
+
         static final String methodName = "DELETE";
 
         @Override
@@ -826,10 +844,10 @@ public class RestClient {
             Request request = Chain.peek().getRequest();
 
             StringBuffer buff = new StringBuffer("");
-            Pattern      p    = Pattern.compile("\\$\\{([^\\}]*)\\}");
-            Matcher      m    = p.matcher(url);
+            Pattern p = Pattern.compile("\\$\\{([^\\}]*)\\}");
+            Matcher m = p.matcher(url);
             while (m.find()) {
-                String key   = m.group(1);
+                String key = m.group(1);
                 String param = request.getUrl().getParam(key);
                 if (param == null)//replacement value was not there
                     param = "${" + key + "}";
@@ -884,12 +902,12 @@ public class RestClient {
         return this;
     }
 
-    public boolean isGzipRequest() {
-        return gzipRequest;
+    public String getCompression() {
+        return compression;
     }
 
-    public RestClient withGzipRequest(boolean gzipRequest) {
-        this.gzipRequest = gzipRequest;
+    public RestClient withCompression(String compression) {
+        this.compression = compression;
         return this;
     }
 
@@ -1101,6 +1119,7 @@ public class RestClient {
      * </pre>
      */
     public abstract class FutureResponse implements RunnableFuture<Response> {
+
         Request                  request           = null;
         Response                 response          = null;
         List<Consumer<Response>> successListeners  = new ArrayList();
@@ -1336,24 +1355,25 @@ public class RestClient {
      * be completed by the time <code>submit</code> returns.
      */
     public static class Executor {
+
         /**
          * The thread pool will be dynamically contracted to this minimum number of worker threads as the queue length shrinks.
          */
-        protected int threadsMin = 1;
+        protected int              threadsMin   = 1;
 
         /**
          * The thread pool will by dynamically expanded up to this max number of worker threads as the queue length grows.
          * <p>
          * If this number is less than 1, then tasks will be executed synchronously in the calling thread, not asynchronously.
          */
-        protected int threadsMax = 50;
+        protected int              threadsMax   = 50;
 
-        protected int queueMax = 500;
+        protected int              queueMax     = 500;
 
-        LinkedList<RunnableFuture> queue   = new LinkedList();
-        Vector<Thread>             threads = new Vector();
+        LinkedList<RunnableFuture> queue        = new LinkedList();
+        Vector<Thread>             threads      = new Vector();
 
-        String threadPrefix = "executor";
+        String                     threadPrefix = "executor";
 
         public Executor() {
 
@@ -1361,9 +1381,10 @@ public class RestClient {
 
         public synchronized Future submit(final Runnable task) {
             return submit(new RunnableFuture() {
-                boolean started = false;
+
+                boolean started  = false;
                 boolean canceled = false;
-                boolean done = false;
+                boolean done     = false;
 
                 @Override
                 public void run() {
@@ -1440,6 +1461,7 @@ public class RestClient {
         synchronized boolean checkStartThread() {
             if (queue.size() > 0 && threads.size() < threadsMax) {
                 Thread t = new Thread(new Runnable() {
+
                     public void run() {
                         processQueue();
                     }
@@ -1503,8 +1525,7 @@ public class RestClient {
                     do {
                         RunnableFuture task = take();
                         task.run();
-                    }
-                    while (queue.size() > 0);
+                    } while (queue.size() > 0);
                 }
             } catch (Exception ex) {
                 ex.printStackTrace();

--- a/inversion-api/src/main/java/io/inversion/utils/RestClient.java
+++ b/inversion-api/src/main/java/io/inversion/utils/RestClient.java
@@ -135,55 +135,55 @@ import java.util.zip.GZIPOutputStream;
  */
 public class RestClient {
 
-    static Log                                       log                = LogFactory.getLog(RestClient.class);
+    static Log                                       log                   = LogFactory.getLog(RestClient.class);
 
-    protected String                                 name               = null;
+    protected String                                 name                  = null;
 
     /**
      * Optional base url that will be prepended to the url arg of any calls assuming that the url arg supplied is a relative path and not an absolute url.
      */
-    protected String                                 url                = null;
+    protected String                                 url                   = null;
 
     /**
      * Indicates the headers from the root inbound Request being handled on this Chain should be included on this request minus any blacklisted headers.
      */
-    protected boolean                                forwardHeaders     = false;
+    protected boolean                                forwardHeaders        = false;
 
     /**
      * Indicates that a request body should be gzipped and the content-encoding header should be sent with value "gzip".
      */
-    protected boolean                                compression        = true;
+    protected boolean                                useCompression           = true;
 
     /**
      * If <code>compression</code> is true, anything over this size in bytes will be compressed.
      */
-    protected int                                    compressionMinSize = 1024;
+    protected int                                    compressionMinSize    = 1024;
 
     /**
      * Always forward these headers.
      *
      * @see #shouldForwardHeader(String)
      */
-    protected Set                                    whitelistHeaders   = new HashSet(Arrays.asList("authorization", "cookie", "x-forwarded-host", " x-forwarded-proto"));
+    protected Set                                    includeForwardHeaders = new HashSet(Arrays.asList("authorization", "cookie", "x-forwarded-host", " x-forwarded-proto"));
 
     /**
      * Never forward these headers.
      *
      * @see #shouldForwardHeader(String)
      */
-    protected Set                                    blacklistHeaders   = new HashSet(Arrays.asList("content-length", "content-type", "content-encoding", "content-language", "content-location", "content-md5", "host"));
+    protected Set                                    excludeForwardHeaders = new HashSet(Arrays.asList("content-length", "content-type", "content-encoding", "content-language", "content-location", "content-md5", "host"));
 
     /**
-     * Headers that are always sent regardless of <code>forwardHeaders</code>, <code>whitelistHeaders</code> and <code>blacklistHeaders</code> state.
+     * Headers that are always sent regardless of <code>forwardHeaders</code>, <code>includeForwardHeaders</code> and <code>excludeForwardHeaders</code> state.
      * <p>
      * These headers will overwrite any caller supplied or forwarded header with the same key, not append to the value list.
      */
-    protected ArrayListValuedHashMap<String, String> forcedHeaders      = new ArrayListValuedHashMap();
+    protected ArrayListValuedHashMap<String, String> forcedHeaders         = new ArrayListValuedHashMap();
 
     /**
      * Indicates the params from the root inbound Request being handled on this Chain should be included on this request minus any blacklisted params.
      */
-    protected boolean                                forwardParams      = false;
+    protected boolean                                forwardParams         = false;
 
     /**
      * Always forward these params.
@@ -191,7 +191,7 @@ public class RestClient {
      *
      * @see #shouldForwardParam(String)
      */
-    protected Set<String>                            whitelistParams    = new HashSet();
+    protected Set<String>                            whitelistParams       = new HashSet();
 
     /**
      * Never forward these params.
@@ -199,19 +199,19 @@ public class RestClient {
      *
      * @see #shouldForwardParam(String)
      */
-    protected Set<String>                            blacklistParams    = new HashSet();
+    protected Set<String>                            blacklistParams       = new HashSet();
 
     /**
      * The thread pool executor used to make asynchronous requests
      */
-    protected Executor                               executor           = null;
+    protected Executor                               executor              = null;
 
     /**
      * The default maximum number of times to retry a request
      * <p>
      * The default value is zero meaning by default, failed requests will not be retried
      */
-    protected int                                    retryMax           = 0;
+    protected int                                    retryMax              = 0;
 
     /**
      * The length of time before the first retry.
@@ -220,45 +220,45 @@ public class RestClient {
      *
      * @see #computeTimeout(Request)
      */
-    protected int                                    retryTimeoutMin    = 10;
+    protected int                                    retryTimeoutMin       = 10;
 
     /**
      * The maximum amount of time to wait before a single retry.
      *
      * @see #computeTimeout(Request)
      */
-    protected int                                    retryTimeoutMax    = 1000;
+    protected int                                    retryTimeoutMax       = 1000;
 
     /**
      * Parameter for default HttpClient configuration
      *
      * @see org.apache.http.client.config.RequstConfig.setSocketTimeout
      */
-    protected int                                    socketTimeout      = 30000;
+    protected int                                    socketTimeout         = 30000;
 
     /**
      * Parameter for default HttpClient configuration
      *
      * @see org.apache.http.client.config.RequstConfig.setConnectTimeout
      */
-    protected int                                    connectTimeout     = 30000;
+    protected int                                    connectTimeout        = 30000;
 
     /**
      * Parameter for default HttpClient configuration
      *
      * @see org.apache.http.client.config.RequstConfig.setConnectionRequestTimeout
      */
-    protected int                                    requestTimeout     = 30000;
+    protected int                                    requestTimeout        = 30000;
 
     /**
      * The underlying HttpClient use for all network comms.
      */
-    protected HttpClient                             httpClient         = null;
+    protected HttpClient                             httpClient            = null;
 
     /**
      * The timer used it trigger retries.
      */
-    Timer                                            timer              = null;
+    Timer                                            timer                 = null;
 
     public RestClient() {
 
@@ -357,7 +357,7 @@ public class RestClient {
      * @param params                optional additional query string params that will overwrite any that may be on url as composed from {@link #buildUrl(String)}
      * @param body                  optional json body
      * @param retryMax              how many times the client should retry if the Request is not successful, if less than zero then this.retriesMax is used
-     * @param headers               headers that will always be sent regardless of {@link #whitelistHeaders}, {@link #blacklistHeaders} but may be overwritten by {@link #forcedHeaders}
+     * @param headers               headers that will always be sent regardless of {@link #includeForwardHeaders}, {@link #excludeForwardHeaders} but may be overwritten by {@link #forcedHeaders}
      * @return a FutureResponse that will asynchronously resolve to a Result
      */
     public FutureResponse call(String method, String fullUrlOrRelativePath, Map<String, String> params, JSNode body, int retryMax, ArrayListValuedHashMap<String, String> headers) {
@@ -567,7 +567,7 @@ public class RestClient {
 
                 byte[] bytes = request.getBody().getBytes("UTF-8");
 
-                if (compression && bytes.length >= compressionMinSize) {
+                if (useCompression && bytes.length >= compressionMinSize) {
                     req.setHeader("Content-Encoding", "gzip");
                     ByteArrayOutputStream obj = new ByteArrayOutputStream();
                     GZIPOutputStream gzip = new GZIPOutputStream(obj);
@@ -896,12 +896,12 @@ public class RestClient {
         return this;
     }
 
-    public boolean hasCompression() {
-        return compression;
+    public boolean isUseCompression() {
+        return useCompression;
     }
 
-    public RestClient withCompression(boolean compression) {
-        this.compression = compression;
+    public RestClient withUseCompression(boolean useCompression) {
+        this.useCompression = useCompression;
         return this;
     }
 
@@ -1008,8 +1008,8 @@ public class RestClient {
 
     protected boolean shouldForwardHeader(String headerKey) {
         return forwardHeaders //
-                && (whitelistHeaders.size() == 0 || whitelistHeaders.contains(headerKey.toLowerCase())) //
-                && (!blacklistHeaders.contains(headerKey.toLowerCase()));
+                && (includeForwardHeaders.size() == 0 || includeForwardHeaders.contains(headerKey.toLowerCase())) //
+                && (!excludeForwardHeaders.contains(headerKey.toLowerCase()));
     }
 
     public RestClient withForwardHeaders(boolean forwardHeaders) {
@@ -1017,19 +1017,35 @@ public class RestClient {
         return this;
     }
 
-    public Set getWhitelistHeaders() {
-        return new HashSet(whitelistHeaders);
+    public Set<String> getIncludeForwardHeaders() {
+        return new HashSet(includeForwardHeaders);
     }
 
-    public RestClient withWhitelistedHeaders(String... headerKeys) {
+    public RestClient withIncludeForwardHeaders(String... headerKeys) {
         for (int i = 0; headerKeys != null && i < headerKeys.length; i++)
-            whitelistHeaders.add(headerKeys[i].toLowerCase());
+            includeForwardHeaders.add(headerKeys[i].toLowerCase());
         return this;
     }
 
-    public RestClient removeWhitelistHeader(String headerKey) {
+    public RestClient removeIncludeForwardHeader(String headerKey) {
         if (headerKey != null)
-            whitelistHeaders.remove(headerKey.toString());
+            includeForwardHeaders.remove(headerKey.toString());
+        return this;
+    }
+
+    public Set getExcludeForwardHeaders() {
+        return new HashSet(excludeForwardHeaders);
+    }
+
+    public RestClient withExcludeForwardHeaders(String... headerKeys) {
+        for (int i = 0; headerKeys != null && i < headerKeys.length; i++)
+            excludeForwardHeaders.add(headerKeys[i].toLowerCase());
+        return this;
+    }
+
+    public RestClient removeExcludeForwardHeader(String headerKey) {
+        if (headerKey != null)
+            excludeForwardHeaders.remove(headerKey.toString());
         return this;
     }
 

--- a/inversion-api/src/main/java/io/inversion/utils/RestClient.java
+++ b/inversion-api/src/main/java/io/inversion/utils/RestClient.java
@@ -151,11 +151,15 @@ public class RestClient {
 
     /**
      * Indicates that a request body should be gzipped and the content-encoding header should be sent with value "gzip".
+     * <p>
+     * Default value is true.
      */
     protected boolean                                useCompression           = true;
 
     /**
-     * If <code>compression</code> is true, anything over this size in bytes will be compressed.
+     * If <code>useCompression</code> is true, anything over this size in bytes will be compressed.
+     * <p>
+     * Default value is 1024.
      */
     protected int                                    compressionMinSize    = 1024;
 

--- a/inversion-api/src/test/java/io/inversion/EngineTest.java
+++ b/inversion-api/src/test/java/io/inversion/EngineTest.java
@@ -84,7 +84,7 @@ public class EngineTest {
 
         Engine e = new Engine(api);
 
-        Request req = null;
+        Request  req = null;
         Response res = null;
 
         res = e.get("http://localhost:8080/api/a/b/c/d/e/f/g");
@@ -107,7 +107,7 @@ public class EngineTest {
 
         Engine e = new Engine(api1, api2);
 
-        Request req = null;
+        Request  req = null;
         Response res = null;
 
         res = e.get("http://localhost:8080/api1/ep1");
@@ -169,19 +169,19 @@ public class EngineTest {
         Api api = null;
 
         api = new Api("test")//
-                             .withAction(new MockAction("mock1"))//
-                             .withEndpoint(new Endpoint("GET", "*").withName("ep1").withExcludeOn(null, "subpath/*"))//
-                             .withEndpoint(new Endpoint("GET", "subpath/*").withName("ep2"))//
-                             .withCollection(new Collection("any").withIncludeOn(null, new Path("{_collection}/[:_resource]/[:_relationship]/*")));
+                .withAction(new MockAction("mock1"))//
+                .withEndpoint(new Endpoint("GET", "*").withName("ep1").withExcludeOn(null, "subpath/*"))//
+                .withEndpoint(new Endpoint("GET", "subpath/*").withName("ep2"))//
+                .withCollection(new Collection("any").withIncludeOn(null, new Path("{_collection}/[:_resource]/[:_relationship]/*")));
 
         assertEndpointMatch("GET", "http://localhost/test/colKey/entKey/relKey", 200, "ep1", "", "colKey", "entKey", "relKey", api);
         assertEndpointMatch("GET", "http://localhost/test/subpath/colKey/entKey/relKey", 200, "ep2", "subpath", "colKey", "entKey", "relKey", api);
 
         api = new Api("test")//
-                             .withAction(new MockAction("mock1"))//
-                             .withEndpoint(new Endpoint("GET", "/[{collection:collection1|collection2}]/*").withName("ep1"))//
-                             .withEndpoint(new Endpoint("GET", "subpath3/*").withName("ep2"))//
-                             .withCollection(new Collection("any").withIncludeOn(null, new Path("{_collection}/[:_resource]/[:_relationship]/*")));
+                .withAction(new MockAction("mock1"))//
+                .withEndpoint(new Endpoint("GET", "/[{collection:collection1|collection2}]/*").withName("ep1"))//
+                .withEndpoint(new Endpoint("GET", "subpath3/*").withName("ep2"))//
+                .withCollection(new Collection("any").withIncludeOn(null, new Path("{_collection}/[:_resource]/[:_relationship]/*")));
 
         assertEndpointMatch("GET", "http://localhost/test/collection1/entKey/relKey", 200, "ep1", "", "collection1", "entKey", "relKey", api);
         assertEndpointMatch("GET", "http://localhost/test/collection2/entKey/relKey", 200, "ep1", "", "collection2", "entKey", "relKey", api);
@@ -198,25 +198,25 @@ public class EngineTest {
         //      assertEndpointMatch("GET", "http://localhost/endpoint_path/12345", 200, "ep0", "endpoint_path", "12345", null, null, api0);
 
         Api api1 = new Api("test")//
-                                  .withAction(new MockAction("mock1"))//
-                                  .withEndpoint(new Endpoint("GET", "ep1/*").withName("ep1"))//
-                                  .withEndpoint(new Endpoint("GET", "ep2/").withName("ep2"))//
-                                  .withEndpoint(new Endpoint().withName("ep3").withIncludeOn("GET", "bookstore/[books]/*", "bookstore/{_collection:categories|author}"))//
-                                  .withEndpoint(new Endpoint().withName("ep4").withIncludeOn("GET" //
-                                          , "other/data/[table1]"//
-                                          , "other/data/[table2]/*"//
-                                          , "other/data/[other]/data/*"//
-                                          , "other/data/[data]/*"))//
-                                  .withEndpoint(new Endpoint("GET", "cardealer/[{type:ford|gm}]/*").withName("ep5"))//
-                                  .withEndpoint(new Endpoint().withName("ep6")//
-                                                              .withIncludeOn("GET", "petstore/*")//
-                                                              .withExcludeOn(null, "petstore/rat", "petstore/snakes/bad", "petstore/cats/*"))//
-                                  .withEndpoint(new Endpoint().withName("ep7")//
-                                                              .withIncludeOn("GET", //
-                                                                      "gamestop/[{collection:nintendo}]/", //
-                                                                      "gamestop/[{collection:xbox}]/*"))//
-                                  .withEndpoint(new Endpoint("GET", "carwash/{_collection:regular|delux}/*").withName("ep8"))//
-                                  .withCollection(new Collection("any").withIncludeOn(null, new Path("{_collection}/[:_resource]/[:_relationship]/*")));
+                .withAction(new MockAction("mock1"))//
+                .withEndpoint(new Endpoint("GET", "ep1/*").withName("ep1"))//
+                .withEndpoint(new Endpoint("GET", "ep2/").withName("ep2"))//
+                .withEndpoint(new Endpoint().withName("ep3").withIncludeOn("GET", "bookstore/[books]/*", "bookstore/{_collection:categories|author}"))//
+                .withEndpoint(new Endpoint().withName("ep4").withIncludeOn("GET" //
+                        , "other/data/[table1]"//
+                        , "other/data/[table2]/*"//
+                        , "other/data/[other]/data/*"//
+                        , "other/data/[data]/*"))//
+                .withEndpoint(new Endpoint("GET", "cardealer/[{type:ford|gm}]/*").withName("ep5"))//
+                .withEndpoint(new Endpoint().withName("ep6")//
+                        .withIncludeOn("GET", "petstore/*")//
+                        .withExcludeOn(null, "petstore/rat", "petstore/snakes/bad", "petstore/cats/*"))//
+                .withEndpoint(new Endpoint().withName("ep7")//
+                        .withIncludeOn("GET", //
+                                "gamestop/[{collection:nintendo}]/", //
+                                "gamestop/[{collection:xbox}]/*"))//
+                .withEndpoint(new Endpoint("GET", "carwash/{_collection:regular|delux}/*").withName("ep8"))//
+                .withCollection(new Collection("any").withIncludeOn(null, new Path("{_collection}/[:_resource]/[:_relationship]/*")));
 
         Api api2 = new Api("other").withEndpoint("*", "otherEp");
         api2.withCollection(new Collection("any").withIncludeOn(null, new Path("{_collection}/[:_resource]/[:_relationship]/*")));
@@ -274,12 +274,12 @@ public class EngineTest {
                 .withAction(new MockAction("mock1"))//
                 .withEndpoint(new Endpoint("GET", "[{_collection:collection1}]/*").withName("ep1"))//
                 .withEndpoint(new Endpoint("GET", "[{_collection:collection2}]/*").withName("ep2"));
-        
-        
+
+
         //String endpointName, String endpointPath, String collectionKey, String resourceKey, String subCollectionKey, Api... apis) {
         //assertEndpointMatch(String method, String url, int statusCode, String endpointName, String endpointPath, String collectionKey, String resourceKey, String subCollectionKey, Api... apis) {
-        assertEndpointMatch("GET", "http://localhost/test/collection2", 200, "ep2", null, null, null, null,  api1);
-        
+        assertEndpointMatch("GET", "http://localhost/test/collection2", 200, "ep2", null, null, null, null, api1);
+
     }
 
     @Test
@@ -287,10 +287,10 @@ public class EngineTest {
         Engine engine = null;
 
         engine = new Engine()//
-                             .withApi(new Api()//
-                                               .withEndpoint("get", "/*")//
-                                               .withAction(new MockActionA())//
-                                               .withDb(new MockDb()));
+                .withApi(new Api()//
+                        .withEndpoint("get", "/*")//
+                        .withAction(new MockActionA())//
+                        .withDb(new MockDb()));
 
         Response resp = engine.get("users");
         resp.dump();
@@ -299,17 +299,17 @@ public class EngineTest {
 
         //action is placed on the endpoint instead of the api
         engine = new Engine()//
-                             .withApi(new Api()//
-                                               .withEndpoint("get", "/*", new MockActionA())//
-                                               .withDb(new MockDb()));
+                .withApi(new Api()//
+                        .withEndpoint("get", "/*", new MockActionA())//
+                        .withDb(new MockDb()));
 
         resp = engine.get("users");
         assertEquals("tester1", resp.find("data.0.firstName"));
 
         engine = new Engine()//
-                             .withApi(new Api("testApi")//
-                                                        .withEndpoint("get", "*", new MockActionA())//
-                                                        .withDb(new MockDb()));
+                .withApi(new Api("testApi")//
+                        .withEndpoint("get", "*", new MockActionA())//
+                        .withDb(new MockDb()));
 
         resp = engine.get("users");
         assertEquals(400, resp.getStatusCode());
@@ -328,12 +328,12 @@ public class EngineTest {
         Engine engine = null;
 
         engine = new Engine()//
-                             .withApi(new Api()//
-                                               .withEndpoint("get", "actionA/*", new MockActionA("get", "*"))//
-                                               .withEndpoint("get", "actionB/*", new MockActionB("get", "*")));
+                .withApi(new Api()//
+                        .withEndpoint("get", "actionA/*", new MockActionA("get", "*"))//
+                        .withEndpoint("get", "actionB/*", new MockActionB("get", "*")));
 
         Response resp = null;
-        JSNode data = null;
+        JSNode   data = null;
 
         resp = engine.get("/actionA/helloworld");
         data = resp.getJson();
@@ -355,8 +355,8 @@ public class EngineTest {
         Engine engine = null;
 
         engine = new Engine()//
-                             .withApi(new Api()//
-                                               .withEndpoint("GET", "actionA/*", new MockActionA("GET", "*")));
+                .withApi(new Api()//
+                        .withEndpoint("GET", "actionA/*", new MockActionA("GET", "*")));
 
         Response resp = null;
         resp = engine.get("/actionA");
@@ -414,8 +414,8 @@ public class EngineTest {
         ep.withAction(actionC);
 
         Engine engine = new Engine()//
-                                    .withApi(new Api("test")//
-                                                            .withEndpoint(ep));
+                .withApi(new Api("test")//
+                        .withEndpoint(ep));
 
         Response res = engine.get("test/test");
         res.dump();

--- a/inversion-api/src/test/java/io/inversion/utils/RestClientTest.java
+++ b/inversion-api/src/test/java/io/inversion/utils/RestClientTest.java
@@ -65,7 +65,7 @@ public class RestClientTest {
             }
         }.withUrl("http://somehost")//
                 .withForwardedHeaders(true)//
-                .withWhitelistedHeaders("header1", "header2", "HEADER3", "Header4");
+                .withIncludeForwardHeaders("header1", "header2", "HEADER3", "Header4");
 
         Engine  engine         = new Engine();
         Request inboundRequest = new Request("GET", "http://localhost:8080/path?param1=a&param2=b", null, Utils.addToMap(new ArrayListValuedHashMap(), "header1", "header1Val", "header2", "header2Val", "header3", "header3Val", "headerX", "headerXVal"), -1);

--- a/inversion-spring-boot/src/main/java/io/inversion/spring/InversionMain.java
+++ b/inversion-spring-boot/src/main/java/io/inversion/spring/InversionMain.java
@@ -16,13 +16,15 @@
  */
 package io.inversion.spring;
 
-import io.inversion.Api;
-import io.inversion.Engine;
-import io.inversion.utils.Utils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+
+import io.inversion.Api;
+import io.inversion.Engine;
+import io.inversion.utils.Utils;
 
 /**
  * Launches your Api in an SpringBoot embedded Tomcat.
@@ -32,10 +34,23 @@ import org.springframework.context.annotation.Bean;
  * way, please check out <code>io.inversion.service.spring.config.EnableInversion</code>
  */
 public class InversionMain {
-    static Engine engine = null;
+
+    protected static Engine             engine  = null;
+
+    protected static ApplicationContext context = null;
 
     public static void main(String[] args) {
         run(new Engine());
+    }
+
+    public static void exit() {
+        if (context != null)
+            SpringApplication.exit(context);
+        context = null;
+    }
+
+    public ApplicationContext getContext() {
+        return context;
     }
 
     /**
@@ -52,14 +67,18 @@ public class InversionMain {
      *
      * @param api
      */
-    public static void run(Api api) {
-        run(new Engine().withApi(api));
+    public static ApplicationContext run(Api api) {
+        return run(new Engine().withApi(api));
     }
 
-    public static void run(Engine engine) {
+    public static ApplicationContext run(Engine engine) {
         try {
+
+            if (context != null)
+                exit();
+
             InversionMain.engine = engine;
-            SpringApplication.run(InversionMain.class);
+            context = SpringApplication.run(InversionMain.class);
         } catch (Throwable e) {
             e = Utils.getCause(e);
             if (Utils.getStackTraceString(e).indexOf("A child container failed during start") > -1) {
@@ -87,6 +106,8 @@ public class InversionMain {
             }
             Utils.rethrow(e);
         }
+
+        return context;
     }
 
     @Bean

--- a/inversion-spring-boot/src/main/java/io/inversion/spring/InversionServletConfig.java
+++ b/inversion-spring-boot/src/main/java/io/inversion/spring/InversionServletConfig.java
@@ -1,20 +1,25 @@
 package io.inversion.spring;
 
-import io.inversion.Engine;
-import io.inversion.EngineServlet;
-import io.inversion.utils.Path;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.catalina.Context;
+import org.apache.catalina.connector.Connector;
 import org.apache.catalina.core.StandardContext;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatContextCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 
-import java.util.ArrayList;
-import java.util.List;
+import io.inversion.Engine;
+import io.inversion.EngineServlet;
+import io.inversion.utils.Path;
 
 @Configuration
 public class InversionServletConfig {
@@ -75,6 +80,17 @@ public class InversionServletConfig {
                 ((StandardContext) context).setAllowCasualMultipartParsing(true);
             }
         });
+        
+        tomcat.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+            @Override
+            public void customize(Connector connector) {
+                AbstractHttp11Protocol httpProtocol = (AbstractHttp11Protocol) connector.getProtocolHandler();
+                httpProtocol.setCompressibleMimeType("text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json");
+                httpProtocol.setCompression("1024");//compresses responses over 1KB.
+            }
+        });
+        
+        
 
         return tomcat;
     }

--- a/inversion-spring-boot/src/test/java/io/inversion/utils/RestClientIntegTest.java
+++ b/inversion-spring-boot/src/test/java/io/inversion/utils/RestClientIntegTest.java
@@ -33,7 +33,7 @@ public class RestClientIntegTest {
             }
         }));
 
-        RestClient client = new RestClient().withGzipRequest(true);
+        RestClient client = new RestClient();
         Response resp = client.post("http://localhost:8080/testme", new JSNode("testing", "yep")).get();
         resp.dump().assertOk();
         assertTrue("yep".equals(resp.find("testing")));

--- a/inversion-spring-boot/src/test/java/io/inversion/utils/RestClientIntegTest.java
+++ b/inversion-spring-boot/src/test/java/io/inversion/utils/RestClientIntegTest.java
@@ -1,0 +1,82 @@
+package io.inversion.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.zip.GZIPInputStream;
+
+import org.junit.jupiter.api.Test;
+
+import io.inversion.Action;
+import io.inversion.Api;
+import io.inversion.ApiException;
+import io.inversion.Request;
+import io.inversion.Response;
+import io.inversion.spring.InversionMain;
+
+public class RestClientIntegTest {
+
+    @Test
+    public void doRequest0_gzip_requests_are_encoded_correctly() throws Exception {
+
+        InversionMain.run(new Api().withEndpoint("*", "*", new Action() {
+
+            public void run(Request req, Response res) throws ApiException {
+
+                if (!"yep".equals(req.getJson().find("testing")))
+                    ApiException.throw500InternalServerError();
+
+                res.withJson(req.getJson());
+            }
+        }));
+
+        RestClient client = new RestClient().withGzipRequest(true);
+        Response resp = client.post("http://localhost:8080/testme", new JSNode("testing", "yep")).get();
+        resp.dump().assertOk();
+        assertTrue("yep".equals(resp.find("testing")));
+    }
+
+    @Test
+    public void doRequest0_gzip_responses_are_decoded_correctly() throws Exception {
+
+        InversionMain.run(new Api().withEndpoint("*", "*", new Action() {
+
+            public void run(Request req, Response res) throws ApiException {
+
+                res.data().add(new JSNode("hello", "world"));
+
+                //this forces the payload response over the 1KB size to trigger gzip compression
+                StringBuffer big = new StringBuffer("");
+                for (int i = 0; i < 2048; i++) {
+                    big.append("0");
+                }
+                res.data().add(new JSNode("big", big.toString()));
+
+            }
+        }));
+
+        //-- the HttpClient will transparently handle gzip decoding
+        //-- this is basic URLConnection test is done to make sure the server
+        //-- is actually sending gzipped content
+        URLConnection conn = new URL("http://localhost:8080/testme").openConnection();
+        conn.setRequestProperty("Accept-Encoding", "gzip");
+        assertEquals("gzip", conn.getHeaderField("Content-Encoding"));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Utils.pipe(new GZIPInputStream(conn.getInputStream()), out);
+        String str = new String(out.toByteArray());
+        JSNode payload = JSNode.parseJsonNode(str);
+        assertEquals("world", payload.find("data.0.hello"));
+
+        //-- now do the test again and the result should be the same
+        //-- but the HttpClient will auto decode and remove/hide the Content-Encoding header
+        RestClient client = new RestClient();
+        Response resp = client.get("http://localhost:8080/testme").get();
+        resp.dump().assertOk();
+        assertTrue("world".equals(resp.find("data.0.hello")));
+
+    }
+
+}


### PR DESCRIPTION
Added RestClient.withCompression(String) method to support request compression and added "Accept-Encoding" to requests so that servers can optionally compress responses.  Tweaked EngineServlet so that Tomcat would correctly apply its gzip output filter and tweaked the InversionServletConfig in SpringBoot to enable response compression.

Both RestClient and a SpringBoot based deployment of Inversion are now setup to gzip compress anything over 1KB.  The server will only compress if the "Accpet-Encoding gzip" header is supplied by the client.