### PR TITLE
when the json is empty, a new json object is generated instead raise …

### DIFF
--- a/inversion-api/src/main/java/io/inversion/utils/Utils.java
+++ b/inversion-api/src/main/java/io/inversion/utils/Utils.java
@@ -1327,9 +1327,12 @@ public class Utils {
 
         type = type.toLowerCase();
 
-        if("json".equalsIgnoreCase(type))
+        if("json".equalsIgnoreCase(type)) {
+            String raw=value.toString();
+            if (raw.isEmpty()) return JSNode.parseJson("{}");
             return JSNode.parseJson(value.toString());
-
+        }
+        
         if(Utils.in(type, "char", "nchar", "clob"))
             value.toString().trim();
 


### PR DESCRIPTION
…an exception when JSNode try to parse an empty string